### PR TITLE
Add replace directive for original package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
     "conflict": {
         "symfony/dependency-injection": "4.1.0"
     },
+    "replace": {
+        "lakion/api-test-case": "self.version"
+    },
     "autoload": {
         "psr-4": {
             "ApiTestCase\\": "src/"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

The original `lakion/api-test-case` package is marked as abandoned on packages and suggests using this package instead. This PR adds a `replace` directive to composer.json so this package can be used to fulfil a dependency to `lakion/api-test-case`. This is important when another dependency still requires `lakion/api-test-case` because the two packages can't be installed side-by-side due to a namespace conflict.