### PR TITLE
Add support for PHPUnit 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/orm": "^2.5",
         "nelmio/alice": "^3.1",
         "phpspec/php-diff": "^1.1",
-        "phpunit/phpunit": "^6.0|^7.0",
+        "phpunit/phpunit": "^6.0|^7.0|^8.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^3.4|^4.0",
         "symfony/finder": "^3.4|^4.0",

--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -105,7 +105,7 @@ abstract class ApiTestCase extends WebTestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (null !== $this->client && null !== $this->client->getContainer()) {
             foreach ($this->client->getContainer()->getMockedServices() as $id => $service) {
@@ -217,7 +217,7 @@ abstract class ApiTestCase extends WebTestCase
         if (!$response->isSuccessful()) {
             $openCommand = isset($_SERVER['OPEN_BROWSER_COMMAND']) ? $_SERVER['OPEN_BROWSER_COMMAND'] : 'open %s';
             $tmpDir = isset($_SERVER['TMP_DIR']) ? $_SERVER['TMP_DIR'] : sys_get_temp_dir();
-            
+
             $filename = PathBuilder::build(rtrim($tmpDir, \DIRECTORY_SEPARATOR), uniqid() . '.html');
             file_put_contents($filename, $response->getContent());
             system(sprintf($openCommand, escapeshellarg($filename)));


### PR DESCRIPTION
Opening against 3.1.4 branch, hoping for 3.1.5 :)

Still needs a fix in Symfony kernel for their `tearDown` and `setUp` methods, but since this should be backwards compatible, no need to wait for merge.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | None
| License         | MIT
