### PR TITLE
Added UUID matcher

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -50,6 +50,11 @@ abstract class ApiTestCase extends WebTestCase
     protected $dataFixturesPath;
 
     /**
+     * @var MatcherFactory
+     */
+    protected $matcherFactory;
+
+    /**
      * @var LoaderInterface
      */
     private $fixtureLoader;
@@ -58,6 +63,13 @@ abstract class ApiTestCase extends WebTestCase
      * @var EntityManager
      */
     private $entityManager;
+
+    public function __construct(?string $name = null, array $data = [], string $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->matcherFactory = new MatcherFactory();
+    }
 
     /**
      * @beforeClass

--- a/src/JsonApiTestCase.php
+++ b/src/JsonApiTestCase.php
@@ -28,7 +28,7 @@ abstract class JsonApiTestCase extends ApiTestCase
      */
     protected function buildMatcher()
     {
-        return MatcherFactory::buildJsonMatcher();
+        return $this->matcherFactory->buildJsonMatcher();
     }
 
     /**

--- a/src/MatcherFactory.php
+++ b/src/MatcherFactory.php
@@ -12,26 +12,24 @@
 namespace ApiTestCase;
 
 use Coduo\PHPMatcher\Factory;
-use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
-use Coduo\PHPMatcher\Parser;
 
-class MatcherFactory
+class MatcherFactory extends Factory\SimpleFactory
 {
     /**
      * @return Matcher
      */
-    public static function buildXmlMatcher()
+    public function buildXmlMatcher()
     {
-        return self::buildMatcher(Matcher\XmlMatcher::class);
+        return $this->buildMatcher(Matcher\XmlMatcher::class);
     }
 
     /**
      * @return Matcher
      */
-    public static function buildJsonMatcher()
+    public function buildJsonMatcher()
     {
-        return self::buildMatcher(Matcher\JsonMatcher::class);
+        return $this->buildMatcher(Matcher\JsonMatcher::class);
     }
 
     /**
@@ -39,66 +37,13 @@ class MatcherFactory
      *
      * @return Matcher
      */
-    protected static function buildMatcher($matcherClass)
+    protected function buildMatcher($matcherClass)
     {
-        $orMatcher = self::buildOrMatcher();
+        $orMatcher = $this->buildOrMatcher();
         $chainMatcher = new Matcher\ChainMatcher(array(
             new $matcherClass($orMatcher),
         ));
 
         return new Matcher($chainMatcher);
-    }
-
-    /**
-     * @return Matcher\ChainMatcher
-     */
-    protected static function buildOrMatcher()
-    {
-        $scalarMatchers = self::buildScalarMatchers();
-        $orMatcher = new Matcher\OrMatcher($scalarMatchers);
-        $arrayMatcher = new Matcher\ArrayMatcher(
-            new Matcher\ChainMatcher(array(
-                $orMatcher,
-                $scalarMatchers
-            )),
-            self::buildParser()
-        );
-
-        $chainMatcher = new Matcher\ChainMatcher(array(
-            $orMatcher,
-            $arrayMatcher,
-        ));
-
-        return $chainMatcher;
-    }
-
-    /**
-     * @return Matcher\ChainMatcher
-     */
-    protected static function buildScalarMatchers()
-    {
-        $parser = self::buildParser();
-
-        return new Matcher\ChainMatcher(array(
-            new Matcher\CallbackMatcher(),
-            new Matcher\ExpressionMatcher(),
-            new Matcher\NullMatcher(),
-            new Matcher\StringMatcher($parser),
-            new Matcher\IntegerMatcher($parser),
-            new Matcher\BooleanMatcher($parser),
-            new Matcher\DoubleMatcher($parser),
-            new Matcher\NumberMatcher($parser),
-            new Matcher\ScalarMatcher(),
-            new Matcher\WildcardMatcher(),
-            new Matcher\UuidMatcher($parser),
-        ));
-    }
-
-    /**
-     * @return Parser
-     */
-    protected static function buildParser()
-    {
-        return new Parser(new Lexer(), new Parser\ExpanderInitializer());
     }
 }

--- a/src/MatcherFactory.php
+++ b/src/MatcherFactory.php
@@ -89,7 +89,8 @@ class MatcherFactory
             new Matcher\DoubleMatcher($parser),
             new Matcher\NumberMatcher($parser),
             new Matcher\ScalarMatcher(),
-            new Matcher\WildcardMatcher()
+            new Matcher\WildcardMatcher(),
+            new Matcher\UuidMatcher($parser),
         ));
     }
 

--- a/src/XmlApiTestCase.php
+++ b/src/XmlApiTestCase.php
@@ -28,7 +28,7 @@ abstract class XmlApiTestCase extends ApiTestCase
      */
     protected function buildMatcher()
     {
-        return MatcherFactory::buildXmlMatcher();
+        return $this->matcherFactory->buildXmlMatcher();
     }
 
     /**

--- a/test/app/config/doctrine/Product.orm.yml
+++ b/test/app/config/doctrine/Product.orm.yml
@@ -12,3 +12,5 @@ ApiTestCase\Test\Entity\Product:
             type: string
         price:
             type: integer
+        uuid:
+            type: string

--- a/test/src/Controller/SampleController.php
+++ b/test/src/Controller/SampleController.php
@@ -130,6 +130,7 @@ class SampleController extends Controller
         $product = new Product();
         $product->setName($request->request->get('name'));
         $product->setPrice($request->request->get('price'));
+        $product->setUuid($request->request->get('uuid'));
 
         /** @var ObjectManager $productManager */
         $productManager = $this->getDoctrine()->getManager();

--- a/test/src/Entity/Product.php
+++ b/test/src/Entity/Product.php
@@ -29,6 +29,11 @@ class Product
     private $price;
 
     /**
+     * @var string
+     */
+    private $uuid;
+
+    /**
      * @return mixed
      */
     public function getId()
@@ -66,5 +71,21 @@ class Product
     public function setPrice($price)
     {
         $this->price = $price;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * @param string $uuid
+     */
+    public function setUuid($uuid)
+    {
+        $this->uuid = $uuid;
     }
 }

--- a/test/src/Tests/Controller/SampleControllerJsonTest.php
+++ b/test/src/Tests/Controller/SampleControllerJsonTest.php
@@ -138,7 +138,8 @@ class SampleControllerJsonTest extends JsonApiTestCase
 <<<EOT
         {
             "name": "Star Wars T-Shirt",
-            "price": 1000
+            "price": 1000,
+            "uuid": "d914ffec-5ad0-4b52-b465-46b10e2548e7"
         }
 EOT;
 

--- a/test/src/Tests/DataFixtures/ORM/product.yml
+++ b/test/src/Tests/DataFixtures/ORM/product.yml
@@ -2,9 +2,12 @@ ApiTestCase\Test\Entity\Product:
     product1:
         name: 'Phone'
         price: 200
+        uuid: '89e05515-1268-4f84-8efc-890137957af8'
     product2:
         name: 'Book'
         price: 15
+        uuid: '3df8852e-76e4-4e76-8fbb-5f73f6260036'
     product3:
         name: 'Mug'
         price: 5
+        uuid: '058db5c6-e1da-40ef-ab53-9c100397a578'

--- a/test/src/Tests/Responses/Expected/category_index.json
+++ b/test/src/Tests/Responses/Expected/category_index.json
@@ -6,17 +6,20 @@
             {
                 "id": @integer@,
                 "name": "Phone",
-                "price": 200
+                "price": 200,
+                "uuid": @uuid@
             },
             {
                 "id": @integer@,
                 "name": "Book",
-                "price": 15
+                "price": 15,
+                "uuid": @uuid@
             },
             {
                 "id": @integer@,
                 "name": "Mug",
-                "price": 5
+                "price": 5,
+                "uuid": @uuid@
             }
         ]
     }

--- a/test/src/Tests/Responses/Expected/category_index.xml
+++ b/test/src/Tests/Responses/Expected/category_index.xml
@@ -7,16 +7,19 @@
       <id>@string@</id>
       <name>Phone</name>
       <price>200</price>
+      <uuid>@uuid@</uuid>
     </products>
     <products>
       <id>@string@</id>
       <name>Book</name>
       <price>15</price>
+      <uuid>@uuid@</uuid>
     </products>
     <products>
       <id>@string@</id>
       <name>Mug</name>
       <price>5</price>
+      <uuid>@uuid@</uuid>
     </products>
   </item>
 </response>

--- a/test/src/Tests/Responses/Expected/create_product.json
+++ b/test/src/Tests/Responses/Expected/create_product.json
@@ -1,5 +1,6 @@
 {
     "id": @integer@,
     "name": "Star Wars T-Shirt",
-    "price": 1000
+    "price": 1000,
+    "uuid": @uuid@
 }

--- a/test/src/Tests/Responses/Expected/get_product.json
+++ b/test/src/Tests/Responses/Expected/get_product.json
@@ -1,5 +1,6 @@
 {
     "id": @integer@,
     "name": "Phone",
-    "price": 200
+    "price": 200,
+    "uuid": @uuid@
 }

--- a/test/src/Tests/Responses/Expected/get_product.xml
+++ b/test/src/Tests/Responses/Expected/get_product.xml
@@ -3,4 +3,5 @@
   <id>@string@</id>
   <name>Phone</name>
   <price>200</price>
+  <uuid>@uuid@</uuid>
 </response>

--- a/test/src/Tests/Responses/Expected/product_index.json
+++ b/test/src/Tests/Responses/Expected/product_index.json
@@ -2,16 +2,19 @@
     {
         "id": @integer@,
         "name": "Phone",
-        "price": 200
+        "price": 200,
+        "uuid": @uuid@
     },
     {
         "id": @integer@,
         "name": "Book",
-        "price": 15
+        "price": 15,
+        "uuid":  @uuid@
     },
     {
         "id": @integer@,
         "name": "Mug",
-        "price": 5
+        "price": 5,
+        "uuid":  @uuid@
     }
 ]

--- a/test/src/Tests/Responses/Expected/product_index.xml
+++ b/test/src/Tests/Responses/Expected/product_index.xml
@@ -4,15 +4,18 @@
     <id>@string@</id>
     <name>Phone</name>
     <price>200</price>
+    <uuid>@uuid@</uuid>
   </item>
   <item key="1">
     <id>@string@</id>
     <name>Book</name>
     <price>15</price>
+    <uuid>@uuid@</uuid>
   </item>
   <item key="2">
     <id>@string@</id>
     <name>Mug</name>
     <price>5</price>
+    <uuid>@uuid@</uuid>
   </item>
 </response>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT


Is there any reason why `MatcherFactory` doesn't extend from https://github.com/coduo/php-matcher/blob/master/src/Factory/SimpleFactory.php? It would prevent this sort of issues in the future.