### PR TITLE
Call \Mockery::close() only if MockerContainer is present

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -126,9 +126,10 @@ abstract class ApiTestCase extends WebTestCase
             foreach ($this->client->getContainer()->getMockedServices() as $id => $service) {
                 $this->client->getContainer()->unmock($id);
             }
+
+            \Mockery::close();
         }
 
-        \Mockery::close();
         $this->client = null;
         $this->entityManager = null;
         $this->fixtureLoader = null;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT

Otherwise it throws an `Class 'Mockery' not found` error.