### PR TITLE
Prevent a warning when installing the lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
         "doctrine/orm": "^2.5",
         "nelmio/alice": "^3.1",
         "phpspec/php-diff": "^1.1",
-        "phpunit/phpunit": "^6.0|^7.0|^8.0",
         "symfony/browser-kit": "^3.4|^4.0",
         "symfony/finder": "^3.4|^4.0",
         "symfony/framework-bundle": "^3.4|^4.0",
+        "symfony/phpunit-bridge": "^3.4|^4.0",
         "theofidry/alice-data-fixtures": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | yes
| Related tickets | n/a
| License         | MIT

Prevents the following Flex warning when installing the library:

````                                                                                             
 Adding phpunit/phpunit as a dependency is discouraged in favor of Symfony's PHPUnit Bridge. 
                                                                                             
  * Instead:
    1. Remove it now: composer remove --dev phpunit/phpunit
    2. Use Symfony's bridge: composer require --dev phpunit
```