### PR TITLE
Make ApiTestCase::tearDown protected

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -117,7 +117,7 @@ abstract class ApiTestCase extends WebTestCase
         }
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (null !== $this->client &&
             null !== $this->client->getContainer() &&


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes?
| New feature?    | no
| BC breaks?      | no
| Related tickets | N/A
| License         | MIT

PHPUnit `TestCase::tearDown` is protected itself, so makes sense for this one to be too.