### PR TITLE
Removing deprecation in the root dir

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -366,7 +366,7 @@ abstract class ApiTestCase extends WebTestCase
     {
         if (null === $this->dataFixturesPath) {
             $this->dataFixturesPath = isset($_SERVER['FIXTURES_DIR']) ?
-                PathBuilder::build($this->getRootDir(), $_SERVER['FIXTURES_DIR'] ) :
+                PathBuilder::build($this->getRootDir(), $_SERVER['FIXTURES_DIR']) :
                 PathBuilder::build($this->getCalledClassFolder(), '..', 'DataFixtures', 'ORM');
         }
 
@@ -429,6 +429,6 @@ abstract class ApiTestCase extends WebTestCase
      */
     private function getRootDir()
     {
-        return $this->get('kernel')->getRootDir();
+        return $this->get('kernel')->getProjectDir();
     }
 }

--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -427,7 +427,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * @return string
      */
-    private function getRootDir()
+     private function getProjectDir()
     {
         return $this->get('kernel')->getProjectDir();
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | kinda
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

Since 4.2 it is deprecated to use `getRootDir` and `getProjectDir` should be used instead/