### PR TITLE
Removing phpunit from prod dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ php:
 
 env:
     - SYMFONY_VERSION=3.4.*
-    - PHPUNIT_VERSION=^6.0
-    - PHPUNIT_VERSION=^7.0
     - CODUO_VERSION=^2.3
     - MOST_RECENT=true
 
@@ -31,12 +29,6 @@ install:
         fi
 
     - |
-        if [ ! -z "${PHPUNIT_VERSION}" ]
-        then
-            composer require --dev "phpunit/phpunit:${PHPUNIT_VERSION}" --no-update --no-scripts --prefer-dist
-        fi
-
-    - |
         if [ ! -z "${CODUO_VERSION}" ]
         then
             composer require "coduo/php-matcher:${CODUO_VERSION}" --no-update --no-scripts --prefer-dist
@@ -51,4 +43,4 @@ script:
     - composer validate --strict
     - composer analyse
 
-    - vendor/bin/phpunit
+    - vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,13 @@
         "doctrine/orm": "^2.5",
         "nelmio/alice": "^3.1",
         "phpspec/php-diff": "^1.1",
-        "phpunit/phpunit": "^6.0|^7.0|^8.0",
         "symfony/browser-kit": "^3.4|^4.0",
         "symfony/finder": "^3.4|^4.0",
         "symfony/framework-bundle": "^3.4|^4.0",
         "theofidry/alice-data-fixtures": "^1.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^6.0|^7.0|^8.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-strict-rules": "^0.11",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "theofidry/alice-data-fixtures": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0|^7.0|^8.0",
+        "symfony/phpunit-bridge": "^3.4|^4.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-strict-rules": "^0.11",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #144 
| License         | MIT

PhpUnit is now only a `dev` dependency.