### PR TITLE
Move MatcherFactory instantiation to @before

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -51,10 +51,11 @@ abstract class ApiTestCase extends WebTestCase
     /** @var EntityManager|null */
     private $entityManager;
 
-    public function __construct(?string $name = null, array $data = [], $dataName = '')
+    /**
+     * @before
+     */
+    public function initMatcherFactory()
     {
-        parent::__construct($name, $data, $dataName);
-
         $this->matcherFactory = new MatcherFactory();
     }
 

--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -54,7 +54,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * @before
      */
-    public function initMatcherFactory()
+    public function initMatcherFactory(): void
     {
         $this->matcherFactory = new MatcherFactory();
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

PHPUnit deprecates the `TestCase::__construct` override possibility, so i move the `MatcherFactory` instantiation to a `@before` tagged method.

@lchrusciel ok for you ?