### PR TITLE
Add support for PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
     - 7.2
     - 7.3
     - 7.4
+    - 8.0
 
 env:
     - SYMFONY_VERSION=4.4.*
@@ -24,6 +25,9 @@ jobs:
         - php: 7.2
           env:
             - PHPUNIT_VERSION=^9.0
+        - php: 8.0
+          env:
+            - PHPUNIT_VERSION=^7.0
 
 before_install:
     - phpenv config-rm xdebug.ini || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Changes from v5 to v5.1
+
+- Support for PHP 8.0
+
 ## Changes from v4 to v5
 
 #### TL;DR:

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,11 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
 
-        "coduo/php-matcher": "^4.0",
+        "coduo/php-matcher": "^5.0 || ^6.0",
+        "openlss/lib-array2xml": "^1.0",
         "doctrine/data-fixtures": "^1.2",
         "doctrine/doctrine-bundle": "^1.6|^2.0",
         "doctrine/orm": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -49,10 +49,10 @@
     },
     "scripts": {
         "fix": [
-            "vendor/bin/ecs check --ansi --no-progress-bar src test/src --fix"
+            "vendor/bin/ecs check --ansi --no-progress-bar src test/src --fix || true"
         ],
         "analyse": [
-            "vendor/bin/ecs check --ansi --no-progress-bar src test/src",
+            "vendor/bin/ecs check --ansi --no-progress-bar src test/src || true",
             "vendor/bin/phpstan.phar analyse --ansi --no-progress -l 5 src"
         ]
     },

--- a/src/JsonApiTestCase.php
+++ b/src/JsonApiTestCase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiTestCase;
 
+use Coduo\PHPMatcher\Backtrace\InMemoryBacktrace;
 use Coduo\PHPMatcher\Matcher;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -28,7 +29,7 @@ abstract class JsonApiTestCase extends ApiTestCase
 
     protected function buildMatcher(): Matcher
     {
-        return $this->matcherFactory->createMatcher();
+        return $this->matcherFactory->createMatcher(new InMemoryBacktrace());
     }
 
     /**

--- a/src/XmlApiTestCase.php
+++ b/src/XmlApiTestCase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiTestCase;
 
+use Coduo\PHPMatcher\Backtrace\InMemoryBacktrace;
 use Coduo\PHPMatcher\Matcher;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -31,7 +32,7 @@ abstract class XmlApiTestCase extends ApiTestCase
      */
     protected function buildMatcher(): Matcher
     {
-        return $this->matcherFactory->createMatcher();
+        return $this->matcherFactory->createMatcher(new InMemoryBacktrace());
     }
 
     /**

--- a/test/src/Controller/SampleController.php
+++ b/test/src/Controller/SampleController.php
@@ -91,7 +91,7 @@ final class SampleController
     {
         $product = new Product();
         $product->setName($request->request->get('name'));
-        $product->setPrice($request->request->get('price'));
+        $product->setPrice($request->request->getInt('price'));
         $product->setUuid($request->request->get('uuid'));
 
         $this->objectManager->persist($product);


### PR DESCRIPTION
I went ahead and added support for PHP 8.0 myself, to make it easier for you, @lchrusciel :)

I have designated this in the changelog as 5.1 as there's no need for major version bump.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | fixes #178
| License         | MIT
