### PR TITLE
Support Symfony 8 and bump doctrine dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,34 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1, 8.2, 8.3]
-                symfony: [6.4.*, 7.0.*]
-                phpunit: [^9.0, ^10.0, ^11.0]
+                php: [8.1, 8.2, 8.3, 8.4]
+                symfony: [6.4.*, 7.3.*, 8.0.*]
+                phpunit: [^10.0, ^11.0]
                 php-matcher: [^6.0]
                 orm: [^2.5, ^3.0]
                 exclude:
                     - php: 8.1
-                      symfony: 7.0.*
+                      symfony: 7.3.*
                     - php: 8.1
                       phpunit: ^11.0
+                    - php: 8.1
+                      symfony: 8.0.*
+                    - php: 8.2
+                      symfony: 8.0.*
+                    - php: 8.3
+                      symfony: 8.0.*
+                    - php: 8.1
+                      symfony: 8.0.*
+                      orm: ^2.5
+                    - php: 8.2
+                      symfony: 8.0.*
+                      orm: ^2.5
+                    - php: 8.3
+                      symfony: 8.0.*
+                      orm: ^2.5
+                    - php: 8.4
+                      symfony: 8.0.*
+                      orm: ^2.5
 
         steps:
         - uses: "actions/checkout@v4"

--- a/composer.json
+++ b/composer.json
@@ -24,26 +24,26 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
 
         "coduo/php-matcher": "^6.0",
         "openlss/lib-array2xml": "^1.0",
-        "doctrine/data-fixtures": "^1.2",
-        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/data-fixtures": "^2.1",
+        "doctrine/doctrine-bundle": "^2.0 || ^3.0",
         "doctrine/orm": "^2.5 || ^3.0",
         "nelmio/alice": "^3.6",
         "phpspec/php-diff": "^1.1",
-        "phpunit/phpunit": "^9.0 || ^10.0 || ^11.0",
-        "symfony/browser-kit": "^6.4 || ^7.0",
-        "symfony/finder": "^6.4 || ^7.0",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
+        "phpunit/phpunit": "^10.0 || ^11.0",
+        "symfony/browser-kit": "^6.4 || ^7.3 || ^8.0",
+        "symfony/finder": "^6.4 || ^7.3 || ^8.0",
+        "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0",
         "theofidry/alice-data-fixtures": "^1.0"
     },
     "require-dev": {
         "phpstan/phpstan-strict-rules": "^1.0",
         "phpstan/phpstan-webmozart-assert": "^1.0",
-        "symfony/serializer": "^5.4 || ^6.0",
+        "symfony/serializer": "^6.4 || ^7.3 || ^8.0",
         "phpstan/phpstan": "^1.8"
     },
     "scripts": {

--- a/test/app/AppKernel.php
+++ b/test/app/AppKernel.php
@@ -44,7 +44,7 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(static function (ContainerBuilder $container): void {
             $container->loadFromExtension('framework', [

--- a/test/src/Controller/SampleController.php
+++ b/test/src/Controller/SampleController.php
@@ -76,10 +76,10 @@ final class SampleController
         return $this->respond($request, $categories);
     }
 
-    public function showAction(Request $request): Response
+    public function showAction(Request $request, int $id): Response
     {
         $productRepository = $this->objectManager->getRepository(Product::class);
-        $product = $productRepository->find($request->get('id'));
+        $product = $productRepository->find($id);
 
         if (!$product) {
             throw new NotFoundHttpException();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Related tickets | 
| License         | MIT

PR to prepare this package for newer symfony and doctrine versions and to unblock other dependencies down the road (sylius/resource-bundle for example) 

* Allow Symfony 8 and remove support for unmaintained Symfony 7 versions
* Bump `doctrine/data-fixtures` to v2 to allow doctrine/persitence v4
  * With this bump doctrine/doctrine-bundle v3 can also be allowed which will unblock Symfony 8 when v3.1 is released

**Dependencies with pending Symfony 8 support:**

| Dependency | Info |
| --- | --- |
| doctrine/doctrine-bundle | symfony 8 support available in 3.1.x-dev |
| doctrine/orm | symfony 8 support available in 3.6.x-dev |
| nelmio/alice | https://github.com/nelmio/alice/pull/1284  |
| theofidry/alice-data-fixtures | Not compatible yet (no work started) https://github.com/theofidry/AliceDataFixtures/issues/318 |

