### PR TITLE
[Maintenance] Add Symfony 8.0 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,6 @@ jobs:
                       phpunit: ^12.0
                     - php: 8.3
                       symfony: 8.0.*
-                    # PHP 8.4+ requires theofidry/alice-data-fixtures 1.11+ which needs Symfony 7.4+
-                    - php: 8.4
-                      symfony: 6.4.*
-                    - php: 8.5
-                      symfony: 6.4.*
 
         steps:
         - uses: "actions/checkout@v4"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,9 @@ jobs:
                       phpunit: ^12.0
                     - php: 8.3
                       symfony: 8.0.*
+                    # Doctrine ORM 2.x is incompatible with doctrine-bundle for Symfony 8
+                    - symfony: 8.0.*
+                      orm: ^2.5
 
         steps:
         - uses: "actions/checkout@v4"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.1, 8.2, 8.3, 8.4, 8.5]
-                symfony: [6.4.*, 7.4.*]
+                symfony: [6.4.*, 7.4.*, 8.0.*]
                 phpunit: [^10.0, ^11.0, ^12.0]
                 php-matcher: [^6.0]
                 orm: [^2.5, ^3.0]
@@ -29,11 +29,17 @@ jobs:
                     - php: 8.1
                       symfony: 7.4.*
                     - php: 8.1
+                      symfony: 8.0.*
+                    - php: 8.1
                       phpunit: ^11.0
                     - php: 8.1
                       phpunit: ^12.0
                     - php: 8.2
+                      symfony: 8.0.*
+                    - php: 8.2
                       phpunit: ^12.0
+                    - php: 8.3
+                      symfony: 8.0.*
 
         steps:
         - uses: "actions/checkout@v4"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,11 @@ jobs:
                       phpunit: ^12.0
                     - php: 8.3
                       symfony: 8.0.*
+                    # PHP 8.4+ requires theofidry/alice-data-fixtures 1.11+ which needs Symfony 7.4+
+                    - php: 8.4
+                      symfony: 6.4.*
+                    - php: 8.5
+                      symfony: 6.4.*
 
         steps:
         - uses: "actions/checkout@v4"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,29 +20,20 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1, 8.2, 8.3, 8.4, 8.5]
+                php: [8.2, 8.3, 8.4, 8.5]
                 symfony: [6.4.*, 7.4.*, 8.0.*]
                 phpunit: [^10.0, ^11.0, ^12.0]
                 php-matcher: [^6.0]
-                orm: [^2.5, ^3.0]
+                orm: [^3.0]
                 exclude:
-                    - php: 8.1
-                      symfony: 7.4.*
-                    - php: 8.1
-                      symfony: 8.0.*
-                    - php: 8.1
-                      phpunit: ^11.0
-                    - php: 8.1
-                      phpunit: ^12.0
+                    # Symfony 8 requires PHP 8.4+
                     - php: 8.2
                       symfony: 8.0.*
-                    - php: 8.2
-                      phpunit: ^12.0
                     - php: 8.3
                       symfony: 8.0.*
-                    # Doctrine ORM 2.x is incompatible with doctrine-bundle for Symfony 8
-                    - symfony: 8.0.*
-                      orm: ^2.5
+                    # PHPUnit 12 requires PHP 8.3+
+                    - php: 8.2
+                      phpunit: ^12.0
 
         steps:
         - uses: "actions/checkout@v4"

--- a/composer.json
+++ b/composer.json
@@ -35,15 +35,15 @@
         "nelmio/alice": "^3.6",
         "phpspec/php-diff": "^1.1",
         "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
-        "symfony/browser-kit": "^6.4 || ^7.4",
-        "symfony/finder": "^6.4 || ^7.4",
-        "symfony/framework-bundle": "^6.4 || ^7.4",
+        "symfony/browser-kit": "^6.4 || ^7.4 || ^8.0",
+        "symfony/finder": "^6.4 || ^7.4 || ^8.0",
+        "symfony/framework-bundle": "^6.4 || ^7.4 || ^8.0",
         "theofidry/alice-data-fixtures": "^1.0"
     },
     "require-dev": {
         "phpstan/phpstan-strict-rules": "^1.0",
         "phpstan/phpstan-webmozart-assert": "^1.0",
-        "symfony/serializer": "^5.4 || ^6.0 || ^7.0",
+        "symfony/serializer": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "phpstan/phpstan": "^1.8"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
 
         "coduo/php-matcher": "^6.0",
         "openlss/lib-array2xml": "^1.0",
         "doctrine/data-fixtures": "^1.2 || ^2.0",
         "doctrine/doctrine-bundle": "^2.0 || ^3.0",
-        "doctrine/orm": "^2.5 || ^3.0",
+        "doctrine/orm": "^3.0",
         "nelmio/alice": "^3.6",
         "phpspec/php-diff": "^1.1",
         "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",

--- a/test/app/AppKernel.php
+++ b/test/app/AppKernel.php
@@ -44,7 +44,7 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(static function (ContainerBuilder $container): void {
             $container->loadFromExtension('framework', [

--- a/test/src/Controller/SampleController.php
+++ b/test/src/Controller/SampleController.php
@@ -79,7 +79,7 @@ final class SampleController
     public function showAction(Request $request): Response
     {
         $productRepository = $this->objectManager->getRepository(Product::class);
-        $product = $productRepository->find($request->get('id'));
+        $product = $productRepository->find($request->attributes->get('id'));
 
         if (!$product) {
             throw new NotFoundHttpException();


### PR DESCRIPTION
- Add ^8.0 constraint to Symfony components in composer.json
- Add Symfony 8.0.* to CI test matrix with PHP 8.4+ exclusions
- Fix breaking changes for Symfony 8 compatibility:
  - Add void return type to AppKernel::registerContainerConfiguration()
  - Replace deprecated Request::get() with Request::attributes->get()

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT
