### PR TITLE
Prepare codebase for major release

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -1,7 +1,7 @@
 imports:
     - { resource: 'vendor/sylius-labs/coding-standard/easy-coding-standard.yml' }
     - { resource: 'vendor/symplify/easy-coding-standard/config/set/clean-code.yaml' }
-    - { resource: 'vendor/symplify/easy-coding-standard/config/set/php71.yaml' }
+    - { resource: 'vendor/symplify/easy-coding-standard/config/set/php82.yaml' }
 
 parameters:
     skip:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,12 @@ includes:
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
 
 parameters:
-    level: 5
+    level: 8
     paths:
         - src
         - test/src/
+    ignoreErrors:
+        # Test code - less strict on nullable checks
+        - '#Cannot call method (request|getResponse)\(\) on Symfony\\Bundle\\FrameworkBundle\\KernelBrowser\|null#'
+        # Test entities - Doctrine handles this
+        - '#Property .* is never written, only read#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,8 +6,3 @@ parameters:
     paths:
         - src
         - test/src/
-    ignoreErrors:
-        # Test code - less strict on nullable checks
-        - '#Cannot call method (request|getResponse)\(\) on Symfony\\Bundle\\FrameworkBundle\\KernelBrowser\|null#'
-        # Test entities - Doctrine handles this
-        - '#Property .* is never written, only read#'

--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -32,26 +32,19 @@ use Webmozart\Assert\Assert;
 
 abstract class ApiTestCase extends WebTestCase
 {
-    /** @var KernelInterface */
-    protected static $sharedKernel;
+    protected static ?KernelInterface $sharedKernel = null;
 
-    /** @var KernelBrowser|null */
-    protected $client;
+    protected ?KernelBrowser $client = null;
 
-    /** @var string|null */
-    protected $expectedResponsesPath;
+    protected ?string $expectedResponsesPath = null;
 
-    /** @var string */
-    protected $dataFixturesPath;
+    protected ?string $dataFixturesPath = null;
 
-    /** @var MatcherFactory|null */
-    protected $matcherFactory;
+    protected ?MatcherFactory $matcherFactory = null;
 
-    /** @var LoaderInterface|null */
-    private $fixtureLoader;
+    private ?LoaderInterface $fixtureLoader = null;
 
-    /** @var EntityManager|null */
-    private $entityManager;
+    private ?EntityManager $entityManager = null;
 
     #[BeforeClass]
     public static function createSharedKernel(): void
@@ -88,6 +81,7 @@ abstract class ApiTestCase extends WebTestCase
     public function setUpDatabase(): void
     {
         if (isset($_SERVER['IS_DOCTRINE_ORM_SUPPORTED']) && $_SERVER['IS_DOCTRINE_ORM_SUPPORTED']) {
+            Assert::notNull(static::$sharedKernel);
             $container = static::$sharedKernel->getContainer();
             Assert::notNull($container);
 
@@ -145,7 +139,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * Gets service from DIC.
      */
-    protected function get(string $id)
+    protected function get(string $id): ?object
     {
         $client = $this->client;
         Assert::notNull($client);
@@ -209,6 +203,9 @@ abstract class ApiTestCase extends WebTestCase
         }
     }
 
+    /**
+     * @return object[]
+     */
     protected function loadFixturesFromDirectory(string $source = ''): array
     {
         $source = $this->getFixtureRealPath($source);
@@ -229,6 +226,9 @@ abstract class ApiTestCase extends WebTestCase
         return $this->getFixtureLoader()->load(array_filter($files));
     }
 
+    /**
+     * @return object[]
+     */
     protected function loadFixturesFromFile(string $source): array
     {
         $source = $this->getFixtureRealPath($source);

--- a/src/JsonApiTestCase.php
+++ b/src/JsonApiTestCase.php
@@ -28,6 +28,8 @@ abstract class JsonApiTestCase extends ApiTestCase
 
     protected function buildMatcher(): Matcher
     {
+        \Webmozart\Assert\Assert::notNull($this->matcherFactory);
+
         return $this->matcherFactory->createMatcher(new VoidBacktrace());
     }
 
@@ -65,15 +67,15 @@ abstract class JsonApiTestCase extends ApiTestCase
         parent::assertResponseContent($this->prettifyJson($response->getContent()), $filename, 'json');
     }
 
-    protected function prettifyJson($content): string
+    protected function prettifyJson(string|false $content): string
     {
         $jsonFlags = \JSON_PRETTY_PRINT;
         if (!isset($_SERVER['ESCAPE_JSON']) || true !== $_SERVER['ESCAPE_JSON']) {
             $jsonFlags |= \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES;
         }
 
-        /** @var string $encodedContent */
-        $encodedContent = json_encode(json_decode($content, true), $jsonFlags);
+        $encodedContent = json_encode(json_decode((string) $content, true), $jsonFlags);
+        \Webmozart\Assert\Assert::string($encodedContent);
 
         return $encodedContent;
     }

--- a/src/XmlApiTestCase.php
+++ b/src/XmlApiTestCase.php
@@ -26,11 +26,10 @@ abstract class XmlApiTestCase extends ApiTestCase
         $this->client = static::createClient([], ['HTTP_ACCEPT' => 'application/xml']);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function buildMatcher(): Matcher
     {
+        \Webmozart\Assert\Assert::notNull($this->matcherFactory);
+
         return $this->matcherFactory->createMatcher(new VoidBacktrace());
     }
 
@@ -68,6 +67,9 @@ abstract class XmlApiTestCase extends ApiTestCase
         $domXmlDocument->formatOutput = true;
         $domXmlDocument->loadXML(str_replace("\n", '', $actualResponse));
 
-        return $domXmlDocument->saveXML();
+        $result = $domXmlDocument->saveXML();
+        \Webmozart\Assert\Assert::string($result);
+
+        return $result;
     }
 }

--- a/test/src/Controller/SampleController.php
+++ b/test/src/Controller/SampleController.php
@@ -37,11 +37,11 @@ final class SampleController
 
     public function helloWorldAction(Request $request): Response
     {
-        $acceptFormat = $request->headers->get('Accept');
+        $acceptFormat = $request->headers->get('Accept') ?? '';
 
         if (
-            false !== strpos($acceptFormat, 'application')
-            && false !== strpos($acceptFormat, 'json')
+            str_contains($acceptFormat, 'application')
+            && str_contains($acceptFormat, 'json')
         ) {
             return new JsonResponse([
                 'message' => 'Hello ApiTestCase World!',
@@ -91,9 +91,9 @@ final class SampleController
     public function createAction(Request $request): Response
     {
         $product = new Product();
-        $product->setName($request->request->get('name'));
+        $product->setName($request->request->getString('name'));
         $product->setPrice($request->request->getInt('price'));
-        $product->setUuid($request->request->get('uuid'));
+        $product->setUuid($request->request->getString('uuid'));
 
         $this->objectManager->persist($product);
         $this->objectManager->flush();
@@ -101,7 +101,7 @@ final class SampleController
         return $this->respond($request, $product, Response::HTTP_CREATED);
     }
 
-    private function respond(Request $request, $data, int $statusCode = Response::HTTP_OK): Response
+    private function respond(Request $request, mixed $data, int $statusCode = Response::HTTP_OK): Response
     {
         $serializer = $this->createSerializer();
         $acceptFormat = $request->headers->get('Accept');
@@ -115,13 +115,11 @@ final class SampleController
             return $response;
         }
 
-        if ('application/json' === $acceptFormat) {
-            $content = $serializer->serialize($data, 'json');
-            $response = new Response($content, $statusCode);
-            $response->headers->set('Content-Type', 'application/json');
+        $content = $serializer->serialize($data, 'json');
+        $response = new Response($content, $statusCode);
+        $response->headers->set('Content-Type', 'application/json');
 
-            return $response;
-        }
+        return $response;
     }
 
     private function createSerializer(): Serializer

--- a/test/src/Entity/Category.php
+++ b/test/src/Entity/Category.php
@@ -29,6 +29,7 @@ class Category
     #[ORM\Column(type: "string")]
     private string $name;
 
+    /** @var Collection<int, Product> */
     #[ORM\ManyToMany(targetEntity: Product::class, cascade: ["all"])]
     #[ORM\JoinTable(
         name: "app_category_products",
@@ -80,7 +81,7 @@ class Category
     }
 
     /**
-     * @return Product[]
+     * @return Collection<int, Product>
      */
     public function getProducts(): Collection
     {

--- a/test/src/Tests/Controller/SampleControllerJsonTest.php
+++ b/test/src/Tests/Controller/SampleControllerJsonTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiTestCase\Test\Tests\Controller;
 
 use ApiTestCase\JsonApiTestCase;
+use ApiTestCase\Test\Entity\Product;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Response;
@@ -39,6 +40,9 @@ class SampleControllerJsonTest extends JsonApiTestCase
         $this->assertResponse($response, 'hello_world');
     }
 
+    /**
+     * @return iterable<array{method: string}>
+     */
     public static function provideTestData(): iterable
     {
         yield ['method' => 'GET'];
@@ -128,6 +132,7 @@ class SampleControllerJsonTest extends JsonApiTestCase
     public function testProductShowResponse(): void
     {
         $objects = $this->loadFixturesFromDirectory();
+        \Webmozart\Assert\Assert::isInstanceOf($objects['product1'], Product::class);
 
         $this->client->request('GET', '/products/' . $objects['product1']->getId());
 

--- a/test/src/Tests/Controller/SampleControllerXmlTest.php
+++ b/test/src/Tests/Controller/SampleControllerXmlTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiTestCase\Test\Tests\Controller;
 
+use ApiTestCase\Test\Entity\Product;
 use ApiTestCase\XmlApiTestCase;
 use PHPUnit\Framework\AssertionFailedError;
 
@@ -82,6 +83,7 @@ class SampleControllerXmlTest extends XmlApiTestCase
     public function testProductShowResponse(): void
     {
         $objects = $this->loadFixturesFromDirectory();
+        \Webmozart\Assert\Assert::isInstanceOf($objects['product1'], Product::class);
 
         $this->client->request('GET', '/products/' . $objects['product1']->getId());
 


### PR DESCRIPTION
- Convert all property docblocks to typed properties
- Add return types to all methods (e.g., get(): ?object)
- Add parameter types (e.g., prettifyJson(string|false $content))
- Upgrade PHPStan level from 5 to 8
- Update ECS configuration from PHP 7.1 to PHP 8.2 standards
- Add proper generic type annotations for Doctrine Collections
- Modernize test files to comply with PHPStan level 8

BREAKING: Requires PHP 8.2+ due to union types and typed properties

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT
